### PR TITLE
Put back old applicationId

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,10 +3,10 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 28
     defaultConfig {
-        applicationId "com.veriff.demo"
+        applicationId "mobi.lab.veriff.demo"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 1
+        versionCode 2
         versionName "2.3.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 28
     defaultConfig {
-        applicationId "mobi.lab.veriff.demo"
+        applicationId "com.veriff.demo"
         minSdkVersion 19
         targetSdkVersion 28
         versionCode 2


### PR DESCRIPTION
Put back old applicationId for release in play store. Will have to delete the current application in play store and release a new one with our new ApplicationId.